### PR TITLE
Changing */ for ×÷

### DIFF
--- a/Project/src/CalcModel.java
+++ b/Project/src/CalcModel.java
@@ -12,7 +12,7 @@ public class CalcModel
 	private final String INITIAL_DISPLAYED_VALUE = "0";
 	private final String INITIAL_DISPLAYED_HISTORY = "start new calculation";
 	
-	private final String BINARY = "+- */";	//The space in the middle is important for checking operator precedence
+	private final String BINARY = "+- ×÷";	//The space in the middle is important for checking operator precedence
 	private final String UNARY  = "sincos!";
 	private final String FACT	= "!";
 	private final String PI 	= "π";
@@ -119,7 +119,7 @@ public class CalcModel
 		calcStack.push(result);
 		preStack.push(secondTop);
 		preStack.push(top);
-		historyStack.push("*");
+		historyStack.push("×");
 		printHistory();
 		updateOperationValue(result);
 	}
@@ -148,7 +148,7 @@ public class CalcModel
 			calcStack.push(result);
 			preStack.push(secondTop);
 			preStack.push(top);
-			historyStack.push("/");
+			historyStack.push("÷");
 			printHistory();
 			updateOperationValue(result);
 		}


### PR DESCRIPTION
I feel that */ should be switched with ×÷ as shown in the requirements mod 1 (it shows only × in the expression list but I think ÷ is good too).
i.e. getHistoryValue() would give
9 × 8 ÷ 7 =
instead of
9 \* 8 / 7 =
